### PR TITLE
Parsing fixes/improvements for state names.

### DIFF
--- a/src/ArrayUtils.py
+++ b/src/ArrayUtils.py
@@ -1,3 +1,22 @@
+# Note: Illegal Windows chars in filenames: <>:"/\|?*
+special_chars = {
+    " ": 0x7F,
+    "(": 0x9A,
+    ")": 0x9B,
+    ":": 0x9C,
+    ";": 0x9D,
+    "[": 0x9E,
+    "]": 0x9F,
+    "é": 0xBA,
+    "'": 0xE0,
+    "-": 0xE3,
+    "?": 0xE6,
+    "!": 0xE7,
+    ".": 0xF2,
+    ",": 0xF4,
+}
+special_chars_inv = {special_chars[k] : k for k in special_chars}
+
 def array_copy(source, srcOffset, destination, destOffset, size=None):
     if size is None:
         size = len(source)
@@ -15,20 +34,22 @@ def array_trim(source):
 def encode_name(name: str) -> bytearray:
     encoded_name = bytearray()
     for i in name:
-        poke_char = 0
-        if i == ' ':
-            poke_char = 127
-        elif i >= '0' and i <= '9':
+        poke_char = special_chars['?']
+        if i >= '0' and i <= '9':
             poke_char = 246 + ord(i) - 48
         elif i >= 'A' and i <= 'Z':
             poke_char = 128 + ord(i) - 65
         elif i >= 'a' and i <= 'z':
             poke_char = 160 + ord(i) - 97
+        elif i in special_chars:
+            poke_char = special_chars[i]
 
         encoded_name.append(poke_char)
 
-    if len(encoded_name) > 16:
-        encoded_name.append(117)
+        if len(encoded_name) == 18:
+            encoded_name[16] = 0x75 # ellipsis
+            encoded_name[17] = 0x50 # string terminator
+            break
 
     return encoded_name
 
@@ -37,14 +58,14 @@ def decode_name(name: bytearray) -> str:
     for i in name:
         poke_char = i & 0xFF
         c = ''
-        if poke_char == 127:
-            c = ' '
-        elif poke_char >= 246 and poke_char <= 255:
+        if poke_char >= 246 and poke_char <= 255:
             c = chr(48 + poke_char - 246)
         elif poke_char >= 128 and poke_char <= 153:
             c = chr(65 + poke_char - 128)
         elif poke_char >= 160 and poke_char <= 185:
             c = chr(97 + poke_char - 160)
+        elif poke_char in special_chars_inv:
+            c = special_chars_inv[poke_char]
         decoded_name += c
 
     return decoded_name

--- a/src/gui.py
+++ b/src/gui.py
@@ -1,7 +1,7 @@
 from PySide2.QtCore import Qt
 from PySide2.QtWidgets import *
 from PySide2.QtGui import QFont
-import os, re
+import os
 
 from patch import *
 from ROM import ROM
@@ -131,11 +131,8 @@ class FlashWindow(QWidget):
 
         filePath, _ = QFileDialog.getOpenFileName(self, 'Load SaveState', '', 'Gambatte Quick Save Files (*.gqs)')
         if filePath:
-            State = make_state('null', filePath, self.rom.game.cgb)
             name = os.path.basename(filePath)[:-4]
-            pattern = re.compile('^[a-zA-Z0-9 ]*$')
-            if re.match(pattern, name):
-                State.set_name(name)
+            State = make_state(name, filePath, self.rom.game.cgb)
 
             item = QListWidgetItem(State.get_name())
             item.setData(0x100, State)


### PR DESCRIPTION
Maybe went overboard, but I added parsing to allow more characters in filenames, and also fixed a couple bugs. (Main motivation was that a handful of the Red savestates on SRC would load as 'null', or had filenames long enough to corrupt the savestate menu screen.)

Specific bugs I ran into (and fixed):
- Long state names were not being truncated as intended, and the screen would get filled with a lot of garbage as a result.
- When a state included invalid characters, the savestate menu would (sometimes?) fail to load, presumably due to the $00 bytes in the strings. (I didn't check to see exactly why this happens, but it's avoidable by not writing the $00 bytes into the state names.)

I elected to change it so any invalid character gets replaced by `?` instead. There are other valid fixes that may be deemed more elegant.

Some byproducts of these changes are no longer having to use 'null' as a placeholder, and no longer having to use a regex to check for a valid filename. I simplified the code in `src/gui.py` accordingly.

(Note: In the future, if we really wanted to get fancy, new characters could be added to the savestate ROMs' font to support more characters. As of now, I think `_` is the only character present in any of the SRC savestate filenames that's currently missing from the font.)