### PR TITLE
Enable automatic scaling on high-DPI monitors.

### DIFF
--- a/src/gui.py
+++ b/src/gui.py
@@ -11,6 +11,7 @@ label_font = QFont('Helvetica', 14, QFont.Bold)
 label_font2 = QFont('Helvetica', 12, QFont.Bold)
 
 def Run():
+    QApplication.setAttribute(Qt.AA_EnableHighDpiScaling)
     app = QApplication([])
     main = PromptWindow()
     main.show()


### PR DESCRIPTION
This is what the program currently looks like on my Windows laptop's High DPI display:
<img src="https://user-images.githubusercontent.com/12521136/137221629-47b2b85d-17f4-4725-af0a-3720c2eaf7ab.png" width="227px" />

Enabling automatic scaling for High DPI makes it look as (presumably) intended:
<img src="https://user-images.githubusercontent.com/12521136/137221822-61a7c28e-0bbc-4aeb-a599-64e6e5605b8f.png" width="452px" />

Assuming this doesn't break anything for normal monitors, it will be a QoL/sanity improvement for some users.
